### PR TITLE
Use Node.js 16 in GitHub workflows

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v2
         with:
-          node-version: '20'
+          node-version: '16'
 
       - name: Clear npm cache
         run: npm cache clean --force

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v2
         with:
-          node-version: '20'
+          node-version: '16'
 
       - name: Install JFrog CLI
         run: curl -fL https://install-cli.jfrog.io | sh
@@ -73,7 +73,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: '20'
+          node-version: '16'
       
       - name: Install JFrog CLI
         run: curl -fL https://install-cli.jfrog.io | sh


### PR DESCRIPTION
Use Node.js 16 in GitHub workflows as this version allows certificates with weak algorithms to be used in the current unit tests.